### PR TITLE
Add next/prev_element_end motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ require("treesitter-sexp").setup {
       form_end = ")",
       prev_elem = "[e",
       next_elem = "]e",
+      prev_elem_end = "[E",
+      next_elem_end = "]E",
       prev_top_level = "[[",
       next_top_level = "]]",
     },

--- a/lua/treesitter-sexp/config.lua
+++ b/lua/treesitter-sexp/config.lua
@@ -23,6 +23,8 @@ M.defaults = {
       form_end = ")",
       prev_elem = "[e",
       next_elem = "]e",
+      prev_elem_end = "[E",
+      next_elem_end = "]E",
       prev_top_level = "[[",
       next_top_level = "]]",
     },

--- a/lua/treesitter-sexp/motions.lua
+++ b/lua/treesitter-sexp/motions.lua
@@ -64,6 +64,32 @@ local M = {
       end
     end,
   },
+  prev_elem_end = {
+    desc = "Previous element end",
+    get_pos = function()
+      local elem = utils.get_elem()
+      if elem ~= nil then
+        local node = utils.get_prev(elem, { "sexp.elem" }, vim.v.count1)
+        if node ~= nil then
+          local _, _, row, col = node:range()
+          return { row, col - 1 }
+        end
+      end
+    end,
+  },
+  next_elem_end = {
+    desc = "Next element end",
+    get_pos = function()
+      local elem = utils.get_elem()
+      if elem ~= nil then
+        local node = utils.get_next(elem, { "sexp.elem" }, vim.v.count1)
+        if node ~= nil then
+          local _, _, row, col = node:range()
+          return { row, col - 1 }
+        end
+      end
+    end,
+  },
   prev_top_level = {
     desc = "Previous top level form",
     get_pos = function()


### PR DESCRIPTION
These motions move to the end of the prev/next element. Similar to sexp_move_to_prev_element_tail and sexp_move_to_next_element_tail.

I find them useful for operating on pairs of elements.

I used default mappings of `[E` and `]E` which feel similar to your own defaults.

Thanks for making this project, and for making it really easy to add new motions like these.