### PR TITLE
Add queries for janet-lang

### DIFF
--- a/queries/janet_simple/sexp.scm
+++ b/queries/janet_simple/sexp.scm
@@ -1,0 +1,6 @@
+(par_tup_lit "(" @sexp.open (_)? @sexp.elem ")" @sexp.close) @sexp.form
+(par_arr_lit "@(" @sexp.open (_)? @sexp.elem ")" @sexp.close) @sexp.form
+(sqr_tup_lit "[" @sexp.open (_)? @sexp.elem "]" @sexp.close) @sexp.form
+(sqr_arr_lit "@[" @sexp.open (_)? @sexp.elem "]" @sexp.close) @sexp.form
+(struct_lit "{" @sexp.open (_)? @sexp.elem "}" @sexp.close) @sexp.form
+(tbl_lit "@{" @sexp.open (_)? @sexp.elem "}" @sexp.close) @sexp.form


### PR DESCRIPTION
Adds queries for working with https://janet-lang.org.

Nvim uses the janet_simple parser by default, hence the directory name.