### PR TITLE
Rename sequence node following new fennel parser

### DIFF
--- a/queries/fennel/sexp.scm
+++ b/queries/fennel/sexp.scm
@@ -1,6 +1,6 @@
 [
  (_ "(" @sexp.open (_)? @sexp.elem ")" @sexp.close)
- (sequential_table "[" @sexp.open (_)? @sexp.elem "]" @sexp.close)
+ (sequence "[" @sexp.open (_)? @sexp.elem "]" @sexp.close)
  (table "{" @sexp.open (_)? @sexp.elem "}" @sexp.close)
  ] @sexp.form
 (program (_) @sexp.elem)


### PR DESCRIPTION
The nvim-treesitter repo recently [switched fennel parsers](https://github.com/nvim-treesitter/nvim-treesitter/commit/7d1bab65469bd53e7a68666de071d9a82a522a40). The [new parser](https://github.com/alexmozaidze/tree-sitter-fennel) defines `sequence` in its grammer for sequence literals, whereas the old one used `sequential_table`. Thus this query needs to be updated.
