### PR TITLE
queries: clojure has-type? updated to kind-eq?

### DIFF
--- a/queries/clojure/sexp.scm
+++ b/queries/clojure/sexp.scm
@@ -39,7 +39,7 @@
   unquoting_lit))
 
 ((_ (_ open: _ @sexp.open close: _ @sexp.close)) @sexp.form
- (#has-type? @sexp.form
+ (#kind-eq? @sexp.form
   derefing_lit
   quoting_lit
   syn_quoting_lit


### PR DESCRIPTION
A suggested fix for the `nvim-treesitter` breaking change, which renames the `has-type?` query to `kind-eq?` query

https://github.com/nvim-treesitter/nvim-treesitter/commit/a80fe081b4c5890980561e0de2458f64aaffbfc7

From a text search of the nvim-treesitter-sexp project, there was only one `has-type` text match, so I changed that to `kind-eq`

This fix seems to work with the setup described in #6  (Neovim 0.10.0 and AstroNvim config) and with the latest (as of 3 days ago) nvim-treesitter plugin.

I dont known if this is the right way to solve the issue, but I can confirm it works.

Resolve #6 