### PR TITLE
Fix Query:iter_matches() breaking change in nvim 0.11

### DIFF
--- a/lua/treesitter-sexp/textobjects.lua
+++ b/lua/treesitter-sexp/textobjects.lua
@@ -1,5 +1,18 @@
-local ts_utils = require "nvim-treesitter.ts_utils"
 local utils = require "treesitter-sexp.utils"
+
+local function update_selection(bufnr, range, mode)
+  local start_row, start_col, end_row, end_col = unpack(range)
+  -- end_col from treesitter is exclusive, visual selection needs inclusive
+  if end_col > 0 then
+    end_col = end_col - 1
+  else
+    end_row = end_row - 1
+    end_col = #vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, false)[1] - 1
+  end
+  vim.api.nvim_buf_set_mark(bufnr, "<", start_row + 1, start_col, {})
+  vim.api.nvim_buf_set_mark(bufnr, ">", end_row + 1, end_col, {})
+  vim.cmd("normal! gv")
+end
 
 ---@type table<string, TSSexp.Textobject>
 local M = {
@@ -64,7 +77,7 @@ local metatable = {
   __call = function(self)
     local range = self.get_range()
     if range ~= nil then
-      ts_utils.update_selection(0, range, "v")
+      update_selection(0, range, "v")
     end
   end,
 }

--- a/lua/treesitter-sexp/utils.lua
+++ b/lua/treesitter-sexp/utils.lua
@@ -34,15 +34,19 @@ function M.get_valid_nodes(pred, comp, capture_names, opts)
   end
 
   local nodes = {}
+  -- TODO abstract away query:iter_matches so that conditional code can be run?
+  -- TODO use conditional vim.version().minor >= 11 to support old version
   for _, match in query:iter_matches(node, 0, start, stop, { max_start_depth = opts.max_start_depth }) do
-    for id, cnode in pairs(match) do
-      local name = query.captures[id]
-      if
-        vim.tbl_contains(capture_names, name)
-        and (vim.tbl_isempty(nodes) or not cnode:equal(nodes[#nodes]))
-        and pred(cnode)
-      then
-        nodes[#nodes + 1] = cnode
+    for id, cnodes in pairs(match) do
+      for _, cnode in pairs(cnodes) do
+        local name = query.captures[id]
+        if
+          vim.tbl_contains(capture_names, name)
+          and (vim.tbl_isempty(nodes) or not cnode:equal(nodes[#nodes]))
+          and pred(cnode)
+        then
+          nodes[#nodes + 1] = cnode
+        end
       end
     end
   end
@@ -67,14 +71,17 @@ function M.get_valid_forms(pred, comp)
   local forms = {}
   for _, match in query:iter_matches(root, 0, cursor_pos[1] - 1, cursor_pos[1]) do
     local result = {}
-    for id, cnode in pairs(match) do
+    for id, cnodes in pairs(match) do
       local name = query.captures[id]
-      if name == "sexp.form" then
-        result.outer = cnode
-      elseif name == "sexp.open" then
-        result.open = cnode
-      elseif name == "sexp.close" then
-        result.close = cnode
+      -- TODO use conditional vim.version().minor >= 11 to support old version
+      for _, cnode in pairs(cnodes) do
+        if name == "sexp.form" then
+          result.outer = cnode
+        elseif name == "sexp.open" then
+          result.open = cnode
+        elseif name == "sexp.close" then
+          result.close = cnode
+        end
       end
     end
     if


### PR DESCRIPTION
https://neovim.io/doc/user/news-0.11.html#news-0.11

Related to #10 and #12.

I would hesitate on merging this as it is. I blindly replaced code where it seemed reasonable.